### PR TITLE
Add rebuild module

### DIFF
--- a/ckanext/sitesearch/cli.py
+++ b/ckanext/sitesearch/cli.py
@@ -2,9 +2,13 @@ import logging
 
 import click
 from ckan.plugins import toolkit
-from ckanext.sitesearch.lib.rebuild import (rebuild_datasets, rebuild_groups,
-                                            rebuild_orgs, rebuild_pages,
-                                            rebuild_users)
+from ckanext.sitesearch.lib.rebuild import (
+    rebuild_datasets,
+    rebuild_groups,
+    rebuild_orgs,
+    rebuild_pages,
+    rebuild_users,
+)
 
 log = logging.getLogger(__name__)
 

--- a/ckanext/sitesearch/cli.py
+++ b/ckanext/sitesearch/cli.py
@@ -1,25 +1,10 @@
-import sys
 import logging
-import traceback
 
 import click
-from sqlalchemy.sql.expression import true, false
-
-from ckan import model
-from ckan.plugins import toolkit, plugin_loaded
-
-from ckan.lib.search import rebuild as core_index_datasets
-
-from ckanext.sitesearch.lib.index import (
-    index_organization,
-    index_group,
-    index_user,
-    index_page,
-    commit,
-)
-
-if plugin_loaded("pages"):
-    from ckanext.pages.db import Page
+from ckan.plugins import toolkit
+from ckanext.sitesearch.lib.rebuild import (rebuild_datasets, rebuild_groups,
+                                            rebuild_orgs, rebuild_pages,
+                                            rebuild_users)
 
 log = logging.getLogger(__name__)
 
@@ -58,155 +43,15 @@ def rebuild(entity_type, commit_each, force, quiet, entity_id=None):
     defer_commit = not commit_each
 
     if entity_type in ("orgs", "org", "organizations", "organisations"):
-        _rebuild_orgs(defer_commit, force, quiet, entity_id)
+        rebuild_orgs(defer_commit, force, quiet, entity_id)
     elif entity_type in ("groups", "group"):
-        _rebuild_groups(defer_commit, force, quiet, entity_id)
+        rebuild_groups(defer_commit, force, quiet, entity_id)
     elif entity_type in ("users", "user"):
-        _rebuild_users(defer_commit, force, quiet, entity_id)
+        rebuild_users(defer_commit, force, quiet, entity_id)
     elif entity_type in ("pages", "page"):
-        if not plugin_loaded("pages"):
-            raise RuntimeError("The `pages` plugin needs to be enabled")
-        _rebuild_pages(defer_commit, force, quiet, entity_id)
+        rebuild_pages(defer_commit, force, quiet, entity_id)
     elif entity_type in ("dataset", "datasets", "package", "packages"):
-        _rebuild_datasets(defer_commit, force, quiet, entity_id)
+        rebuild_datasets(defer_commit, force, quiet, entity_id)
     else:
         toolkit.error_shout("Unknown entity type: {}".format(entity_type))
         raise click.Abort()
-
-
-def _rebuild_orgs(defer_commit, force, quiet, entity_id):
-
-    if entity_id:
-        org = model.Group.get(entity_id)
-        if not org:
-            raise click.UsageError("Organization not found: {}".format(entity_id))
-        org_ids = [org.id]
-    else:
-        org_ids = [
-            r[0]
-            for r in model.Session.query(model.Group.id)
-            .filter(model.Group.is_organization == true())
-            .filter(model.Group.state != "deleted")
-            .all()
-        ]
-
-    _rebuild_entities(
-        org_ids, "organization", "organization_show", defer_commit, force, quiet
-    )
-
-
-def _rebuild_groups(defer_commit, force, quiet, entity_id):
-
-    if entity_id:
-        group = model.Group.get(entity_id)
-        if not group:
-            raise click.UsageError("Group not found: {}".format(entity_id))
-        group_ids = [group.id]
-    else:
-        group_ids = [
-            r[0]
-            for r in model.Session.query(model.Group.id)
-            .filter(model.Group.is_organization == false())
-            .filter(model.Group.state != "deleted")
-            .all()
-        ]
-
-    _rebuild_entities(group_ids, "group", "group_show", defer_commit, force, quiet)
-
-
-def _rebuild_users(defer_commit, force, quiet, entity_id):
-
-    if entity_id:
-        user = model.User.get(entity_id)
-        if not user:
-            raise click.UsageError("User not found: {}".format(entity_id))
-        user_ids = [user.id]
-    else:
-        user_ids = [
-            r[0]
-            for r in model.Session.query(model.User.id)
-            .filter(model.User.state != "deleted")
-            .all()
-        ]
-
-    _rebuild_entities(user_ids, "user", "user_show", defer_commit, force, quiet)
-
-
-def _rebuild_pages(defer_commit, force, quiet, entity_id):
-
-    if entity_id:
-
-        page = Page.get(name=entity_id)
-        if not page:
-            raise click.UsageError("Page not found: {}".format(entity_id))
-        page_ids = [page.name]
-    else:
-        pages = Page.pages()
-        page_ids = [r.name for r in pages]
-
-    _rebuild_entities(
-        page_ids,
-        "page",
-        "ckanext_pages_show",
-        defer_commit,
-        force,
-        quiet,
-        id_field="page",
-    )
-
-
-def _rebuild_datasets(defer_commit, force, quiet, entity_id):
-
-    if toolkit.check_ckan_version(min_version="2.10"):
-        # CKAN >= 2.10 does not clear the index by default
-        core_index_datasets(
-            package_id=entity_id,
-            force=force,
-            quiet=quiet,
-            defer_commit=defer_commit,
-        )
-    else:
-        core_index_datasets(
-            refresh=True,  # Ensure we are not clearing the index for other enitities
-            package_id=entity_id,
-            force=force,
-            quiet=quiet,
-            defer_commit=defer_commit,
-        )
-
-
-indexers = {
-    "organization": index_organization,
-    "group": index_group,
-    "user": index_user,
-    "page": index_page,
-}
-
-
-def _rebuild_entities(
-    entity_ids, entity_name, action_name, defer_commit, force, quiet, id_field="id"
-):
-
-    total_entities = len(entity_ids)
-    context = {"ignore_auth": True}
-    for counter, entity_id in enumerate(entity_ids):
-        if not quiet:
-            sys.stdout.write(
-                "\rIndexing {} {}/{}".format(entity_name, counter + 1, total_entities)
-            )
-            sys.stdout.flush()
-        try:
-            data_dict = toolkit.get_action(action_name)(context, {id_field: entity_id})
-            indexers[entity_name](data_dict, defer_commit)
-        except Exception as e:
-            log.error(
-                "Error while indexing {} {}: {}".format(entity_name, entity_id, repr(e))
-            )
-            if force:
-                log.exception(traceback.format_exc())
-                continue
-            else:
-                raise
-
-    if defer_commit:
-        commit()

--- a/ckanext/sitesearch/lib/rebuild.py
+++ b/ckanext/sitesearch/lib/rebuild.py
@@ -17,7 +17,7 @@ if plugin_loaded("pages"):
 log = logging.getLogger(__name__)
 
 
-def rebuild_orgs(defer_commit, force, quiet, entity_id):
+def rebuild_orgs(defer_commit=False, force=False, quiet=True, entity_id=None):
     if entity_id:
         org = model.Group.get(entity_id)
         if not org:
@@ -37,7 +37,7 @@ def rebuild_orgs(defer_commit, force, quiet, entity_id):
     )
 
 
-def rebuild_groups(defer_commit, force, quiet, entity_id):
+def rebuild_groups(defer_commit=False, force=False, quiet=True, entity_id=None):
 
     if entity_id:
         group = model.Group.get(entity_id)
@@ -56,7 +56,7 @@ def rebuild_groups(defer_commit, force, quiet, entity_id):
     _rebuild_entities(group_ids, "group", "group_show", defer_commit, force, quiet)
 
 
-def rebuild_users(defer_commit, force, quiet, entity_id):
+def rebuild_users(defer_commit=False, force=False, quiet=True, entity_id=None):
 
     if entity_id:
         user = model.User.get(entity_id)
@@ -74,7 +74,7 @@ def rebuild_users(defer_commit, force, quiet, entity_id):
     _rebuild_entities(user_ids, "user", "user_show", defer_commit, force, quiet)
 
 
-def rebuild_pages(defer_commit, force, quiet, entity_id):
+def rebuild_pages(defer_commit=False, force=False, quiet=True, entity_id=None):
 
     if not plugin_loaded("pages"):
         raise RuntimeError("The `pages` plugin needs to be enabled")
@@ -99,7 +99,7 @@ def rebuild_pages(defer_commit, force, quiet, entity_id):
     )
 
 
-def rebuild_datasets(defer_commit, force, quiet, entity_id):
+def rebuild_datasets(defer_commit=False, force=False, quiet=True, entity_id=None):
 
     if toolkit.check_ckan_version(min_version="2.10"):
         # CKAN >= 2.10 does not clear the index by default

--- a/ckanext/sitesearch/lib/rebuild.py
+++ b/ckanext/sitesearch/lib/rebuild.py
@@ -5,10 +5,13 @@ import traceback
 from ckan import model
 from ckan.lib.search import rebuild as core_index_datasets
 from ckan.plugins import plugin_loaded, toolkit
-from ckanext.sitesearch.lib.index import (commit, index_group,
-                                          index_organization,
-                                          index_page,
-                                          index_user)
+from ckanext.sitesearch.lib.index import (
+    commit,
+    index_group,
+    index_organization,
+    index_page,
+    index_user,
+)
 from sqlalchemy.sql.expression import false, true
 
 if plugin_loaded("pages"):

--- a/ckanext/sitesearch/lib/rebuild.py
+++ b/ckanext/sitesearch/lib/rebuild.py
@@ -18,7 +18,6 @@ log = logging.getLogger(__name__)
 
 
 def rebuild_orgs(defer_commit, force, quiet, entity_id):
-    print(entity_id)
     if entity_id:
         org = model.Group.get(entity_id)
         if not org:

--- a/ckanext/sitesearch/lib/rebuild.py
+++ b/ckanext/sitesearch/lib/rebuild.py
@@ -1,0 +1,157 @@
+import logging
+import sys
+import traceback
+
+from ckan import model
+from ckan.lib.search import rebuild as core_index_datasets
+from ckan.plugins import plugin_loaded, toolkit
+from ckanext.sitesearch.lib.index import (commit, index_group,
+                                          index_organization,
+                                          index_page,
+                                          index_user)
+from sqlalchemy.sql.expression import false, true
+
+if plugin_loaded("pages"):
+    from ckanext.pages.db import Page
+
+log = logging.getLogger(__name__)
+
+
+def rebuild_orgs(defer_commit, force, quiet, entity_id):
+    print(entity_id)
+    if entity_id:
+        org = model.Group.get(entity_id)
+        if not org:
+            raise toolkit.ObjectNotFound("Organization not found: {}".format(entity_id))
+        org_ids = [org.id]
+    else:
+        org_ids = [
+            r[0]
+            for r in model.Session.query(model.Group.id)
+            .filter(model.Group.is_organization == true())
+            .filter(model.Group.state != "deleted")
+            .all()
+        ]
+
+    _rebuild_entities(
+        org_ids, "organization", "organization_show", defer_commit, force, quiet
+    )
+
+
+def rebuild_groups(defer_commit, force, quiet, entity_id):
+
+    if entity_id:
+        group = model.Group.get(entity_id)
+        if not group:
+            raise toolkit.ObjectNotFound("Group not found: {}".format(entity_id))
+        group_ids = [group.id]
+    else:
+        group_ids = [
+            r[0]
+            for r in model.Session.query(model.Group.id)
+            .filter(model.Group.is_organization == false())
+            .filter(model.Group.state != "deleted")
+            .all()
+        ]
+
+    _rebuild_entities(group_ids, "group", "group_show", defer_commit, force, quiet)
+
+
+def rebuild_users(defer_commit, force, quiet, entity_id):
+
+    if entity_id:
+        user = model.User.get(entity_id)
+        if not user:
+            raise toolkit.ObjectNotFound("User not found: {}".format(entity_id))
+        user_ids = [user.id]
+    else:
+        user_ids = [
+            r[0]
+            for r in model.Session.query(model.User.id)
+            .filter(model.User.state != "deleted")
+            .all()
+        ]
+
+    _rebuild_entities(user_ids, "user", "user_show", defer_commit, force, quiet)
+
+
+def rebuild_pages(defer_commit, force, quiet, entity_id):
+
+    if not plugin_loaded("pages"):
+        raise RuntimeError("The `pages` plugin needs to be enabled")
+
+    if entity_id:
+        page = Page.get(name=entity_id)
+        if not page:
+            raise toolkit.ObjectNotFound("Page not found: {}".format(entity_id))
+        page_ids = [page.name]
+    else:
+        pages = Page.pages()
+        page_ids = [r.name for r in pages]
+
+    _rebuild_entities(
+        page_ids,
+        "page",
+        "ckanext_pages_show",
+        defer_commit,
+        force,
+        quiet,
+        id_field="page",
+    )
+
+
+def rebuild_datasets(defer_commit, force, quiet, entity_id):
+
+    if toolkit.check_ckan_version(min_version="2.10"):
+        # CKAN >= 2.10 does not clear the index by default
+        core_index_datasets(
+            package_id=entity_id,
+            force=force,
+            quiet=quiet,
+            defer_commit=defer_commit,
+        )
+    else:
+        core_index_datasets(
+            refresh=True,  # Ensure we are not clearing the index for other entities
+            package_id=entity_id,
+            force=force,
+            quiet=quiet,
+            defer_commit=defer_commit,
+        )
+
+
+indexers = {
+    "organization": index_organization,
+    "group": index_group,
+    "user": index_user,
+    "page": index_page,
+}
+
+
+def _rebuild_entities(
+    entity_ids, entity_name, action_name, defer_commit, force, quiet, id_field="id"
+):
+
+    total_entities = len(entity_ids)
+    context = {"ignore_auth": True}
+    for counter, entity_id in enumerate(entity_ids):
+        if not quiet:
+            sys.stdout.write(
+                "\rIndexing {} {}/{}".format(entity_name, counter + 1, total_entities)
+            )
+            sys.stdout.flush()
+        try:
+            data_dict = toolkit.get_action(action_name)(context, {id_field: entity_id})
+            indexers[entity_name](data_dict, defer_commit)
+        except Exception as e:
+            log.error(
+                "Error while indexing {} {}: {}".format(entity_name, entity_id, repr(e))
+            )
+            if force:
+                log.exception(traceback.format_exc())
+                continue
+            else:
+                raise
+
+    if defer_commit:
+        commit()

--- a/ckanext/sitesearch/logic/action.py
+++ b/ckanext/sitesearch/logic/action.py
@@ -283,10 +283,12 @@ def package_groups(context, data_dict):
     for group in groups:
         if group.is_organization:
             group_dict = toolkit.get_action("organization_show")(
-                context, {"id": group.id}
+                context.copy(), {"id": group.id}
             )
         else:
-            group_dict = toolkit.get_action("group_show")(context, {"id": group.id})
+            group_dict = toolkit.get_action("group_show")(
+                context.copy(), {"id": group.id}
+            )
         result.append(group_dict)
 
     return result

--- a/ckanext/sitesearch/logic/action.py
+++ b/ckanext/sitesearch/logic/action.py
@@ -267,3 +267,26 @@ def _get_user_page_labels(user_id):
     labels.extend("group_id-%s" % o["id"] for o in orgs)
 
     return labels
+
+
+def package_groups(context, data_dict):
+    """Returns a list of all the groups the package is a member of"""
+    package_id = toolkit.get_or_bust(data_dict, "id")
+
+    pkg = model.Package.get(package_id)
+    if not pkg:
+        raise toolkit.ObjectNotFound
+
+    groups = pkg.get_groups()
+
+    result = []
+    for group in groups:
+        if group.is_organization:
+            group_dict = toolkit.get_action("organization_show")(
+                context, {"id": group.id}
+            )
+        else:
+            group_dict = toolkit.get_action("group_show")(context, {"id": group.id})
+        result.append(group_dict)
+
+    return result

--- a/ckanext/sitesearch/logic/action.py
+++ b/ckanext/sitesearch/logic/action.py
@@ -267,15 +267,3 @@ def _get_user_page_labels(user_id):
     labels.extend("group_id-%s" % o["id"] for o in orgs)
 
     return labels
-
-
-def rebuild_organizations_index(context, data_dict):
-
-    toolkit.check_access("group_update", context, data_dict)
-
-    defer_commit = data_dict.get("defer_commit", False)
-    force = data_dict.get("force", False)
-    quiet = data_dict.get("quiet", True)
-    entity_id = data_dict.get("id", None)
-
-    rebuild.rebuild_orgs(defer_commit, force, quiet, entity_id)

--- a/ckanext/sitesearch/logic/action.py
+++ b/ckanext/sitesearch/logic/action.py
@@ -267,28 +267,3 @@ def _get_user_page_labels(user_id):
     labels.extend("group_id-%s" % o["id"] for o in orgs)
 
     return labels
-
-
-def package_groups(context, data_dict):
-    """Returns a list of all the groups the package is a member of"""
-    package_id = toolkit.get_or_bust(data_dict, "id")
-
-    pkg = model.Package.get(package_id)
-    if not pkg:
-        raise toolkit.ObjectNotFound
-
-    groups = pkg.get_groups()
-
-    result = []
-    for group in groups:
-        if group.is_organization:
-            group_dict = toolkit.get_action("organization_show")(
-                context.copy(), {"id": group.id}
-            )
-        else:
-            group_dict = toolkit.get_action("group_show")(
-                context.copy(), {"id": group.id}
-            )
-        result.append(group_dict)
-
-    return result

--- a/ckanext/sitesearch/logic/action.py
+++ b/ckanext/sitesearch/logic/action.py
@@ -5,7 +5,7 @@ from ckan import plugins as p
 from ckan.plugins import toolkit, plugin_loaded
 
 from ckanext.sitesearch.logic.schema import default_search_schema
-from ckanext.sitesearch.lib import query
+from ckanext.sitesearch.lib import rebuild, query
 from ckanext.sitesearch.interfaces import ISiteSearch
 
 
@@ -267,3 +267,15 @@ def _get_user_page_labels(user_id):
     labels.extend("group_id-%s" % o["id"] for o in orgs)
 
     return labels
+
+
+def rebuild_organizations_index(context, data_dict):
+
+    toolkit.check_access("group_update", context, data_dict)
+
+    defer_commit = data_dict.get("defer_commit", False)
+    force = data_dict.get("force", False)
+    quiet = data_dict.get("quiet", True)
+    entity_id = data_dict.get("id", None)
+
+    rebuild.rebuild_orgs(defer_commit, force, quiet, entity_id)

--- a/ckanext/sitesearch/logic/chained_action.py
+++ b/ckanext/sitesearch/logic/chained_action.py
@@ -1,6 +1,18 @@
 from ckan.plugins import toolkit
 
-from ckanext.sitesearch.lib import index
+from ckanext.sitesearch.lib import index, rebuild
+
+
+@toolkit.chained_action
+def package_create(up_func, context, data_dict):
+
+    data_dict = up_func(context, data_dict)
+
+    owner_org = data_dict.get("owner_org", None)
+    if owner_org:
+        rebuild.rebuild_orgs(entity_id=owner_org)
+
+    return data_dict
 
 
 @toolkit.chained_action

--- a/ckanext/sitesearch/logic/chained_action.py
+++ b/ckanext/sitesearch/logic/chained_action.py
@@ -16,6 +16,20 @@ def package_create(up_func, context, data_dict):
 
 
 @toolkit.chained_action
+def package_delete(up_func, context, data_dict):
+    package_id = toolkit.get_or_bust(data_dict, "id")
+    dataset = toolkit.get_action("package_show")(context, {"id": package_id})
+
+    up_func(context, data_dict)
+
+    owner_org = dataset.get("owner_org", None)
+    if owner_org:
+        rebuild.rebuild_orgs(entity_id=owner_org)
+
+    return data_dict
+
+
+@toolkit.chained_action
 def organization_create(up_func, context, data_dict):
 
     data_dict = up_func(context, data_dict)

--- a/ckanext/sitesearch/plugin.py
+++ b/ckanext/sitesearch/plugin.py
@@ -41,7 +41,6 @@ class SitesearchPlugin(plugins.SingletonPlugin):
             "user_delete": chained_action.user_delete,
             "package_create": chained_action.package_create,
             "package_delete": chained_action.package_delete,
-            "rebuild_organizations_index": action.rebuild_organizations_index,
         }
         if plugins.plugin_loaded("pages"):
             actions["page_search"] = action.page_search

--- a/ckanext/sitesearch/plugin.py
+++ b/ckanext/sitesearch/plugin.py
@@ -39,6 +39,7 @@ class SitesearchPlugin(plugins.SingletonPlugin):
             "user_create": chained_action.user_create,
             "user_update": chained_action.user_update,
             "user_delete": chained_action.user_delete,
+            "package_create": chained_action.package_create,
             "rebuild_organizations_index": action.rebuild_organizations_index,
         }
         if plugins.plugin_loaded("pages"):

--- a/ckanext/sitesearch/plugin.py
+++ b/ckanext/sitesearch/plugin.py
@@ -41,6 +41,7 @@ class SitesearchPlugin(plugins.SingletonPlugin):
             "user_delete": chained_action.user_delete,
             "package_create": chained_action.package_create,
             "package_delete": chained_action.package_delete,
+            "member_create": chained_action.member_create,
         }
         if plugins.plugin_loaded("pages"):
             actions["page_search"] = action.page_search

--- a/ckanext/sitesearch/plugin.py
+++ b/ckanext/sitesearch/plugin.py
@@ -40,6 +40,7 @@ class SitesearchPlugin(plugins.SingletonPlugin):
             "user_update": chained_action.user_update,
             "user_delete": chained_action.user_delete,
             "package_create": chained_action.package_create,
+            "package_delete": chained_action.package_delete,
             "rebuild_organizations_index": action.rebuild_organizations_index,
         }
         if plugins.plugin_loaded("pages"):

--- a/ckanext/sitesearch/plugin.py
+++ b/ckanext/sitesearch/plugin.py
@@ -39,6 +39,7 @@ class SitesearchPlugin(plugins.SingletonPlugin):
             "user_create": chained_action.user_create,
             "user_update": chained_action.user_update,
             "user_delete": chained_action.user_delete,
+            "rebuild_organizations_index": action.rebuild_organizations_index,
         }
         if plugins.plugin_loaded("pages"):
             actions["page_search"] = action.page_search

--- a/ckanext/sitesearch/tests/test_rebuild.py
+++ b/ckanext/sitesearch/tests/test_rebuild.py
@@ -5,7 +5,6 @@ from ckan.tests import factories, helpers
 
 @pytest.mark.usefixtures("clean_db", "clean_index")
 class TestOrgMetadataUpdate(object):
-
     def test_org_package_count_is_updated(self):
         org = factories.Organization()
 
@@ -13,13 +12,20 @@ class TestOrgMetadataUpdate(object):
         assert result["count"] == 1
         assert result["results"][0]["package_count"] == 0
 
-        helpers.call_action(
-            "package_create",
-            {},
-            name="testing-package",
-            owner_org=org["id"]
+        dataset = helpers.call_action(
+            "package_create", {}, name="testing-package", owner_org=org["id"]
         )
 
         result = helpers.call_action("organization_search", {}, q="*:*")
         assert result["count"] == 1
         assert result["results"][0]["package_count"] == 1
+
+        helpers.call_action(
+            "package_delete",
+            {},
+            id=dataset["id"],
+        )
+
+        result = helpers.call_action("organization_search", {}, q="*:*")
+        assert result["count"] == 1
+        assert result["results"][0]["package_count"] == 0

--- a/ckanext/sitesearch/tests/test_rebuild.py
+++ b/ckanext/sitesearch/tests/test_rebuild.py
@@ -1,19 +1,17 @@
 import pytest
 
-from ckan.lib.search import clear_all
+from ckan.lib.search import clear_all as reset_index
 from ckan.tests import factories, helpers
 
 
-@pytest.fixture(scope="class")
-def reset():
-    yield
-    helpers.reset_db()
-    clear_all()
+@pytest.mark.usefixtures("clean_db", "clean_index")
+class TestRebuild:
+    @classmethod
+    def teardown_class(cls):
+        helpers.reset_db()
+        reset_index()
 
-
-@pytest.mark.usefixtures("reset")
-class TestOrgMetadataUpdate(object):
-    def test_org_package_count_is_updated(self):
+    def test_organization_package_count_is_updated(self):
         org = factories.Organization()
 
         result = helpers.call_action("organization_search", {}, q="*:*")
@@ -35,5 +33,37 @@ class TestOrgMetadataUpdate(object):
         )
 
         result = helpers.call_action("organization_search", {}, q="*:*")
+        assert result["count"] == 1
+        assert result["results"][0]["package_count"] == 0
+
+    def test_group_package_count_is_updated(self):
+        group = factories.Group()
+        org = factories.Organization()
+
+        result = helpers.call_action("group_search", {}, q="*:*")
+        assert result["count"] == 1
+        assert result["results"][0]["package_count"] == 0
+
+        dataset = factories.Dataset(owner_org=org["id"])
+
+        helpers.call_action(
+            "member_create",
+            object=dataset["id"],
+            id=group["id"],
+            object_type="package",
+            capacity="member",
+        )
+
+        result = helpers.call_action("group_search", {}, q="*:*")
+        assert result["count"] == 1
+        assert result["results"][0]["package_count"] == 1
+
+        helpers.call_action(
+            "package_delete",
+            {},
+            id=dataset["id"],
+        )
+
+        result = helpers.call_action("group_search", {}, q="*:*")
         assert result["count"] == 1
         assert result["results"][0]["package_count"] == 0

--- a/ckanext/sitesearch/tests/test_rebuild.py
+++ b/ckanext/sitesearch/tests/test_rebuild.py
@@ -6,7 +6,7 @@ from ckan.tests import factories, helpers
 @pytest.mark.usefixtures("clean_db", "clean_index")
 class TestOrgMetadataUpdate(object):
 
-    def test_package_count_is_updated(self):
+    def test_org_package_count_is_updated(self):
         org = factories.Organization()
 
         result = helpers.call_action("organization_search", {}, q="*:*")
@@ -19,12 +19,6 @@ class TestOrgMetadataUpdate(object):
             name="testing-package",
             owner_org=org["id"]
         )
-
-        result = helpers.call_action("organization_search", {}, q="*:*")
-        assert result["count"] == 1
-        assert result["results"][0]["package_count"] == 0
-
-        helpers.call_action("rebuild_organizations_index")
 
         result = helpers.call_action("organization_search", {}, q="*:*")
         assert result["count"] == 1

--- a/ckanext/sitesearch/tests/test_rebuild.py
+++ b/ckanext/sitesearch/tests/test_rebuild.py
@@ -1,0 +1,31 @@
+import pytest
+
+from ckan.tests import factories, helpers
+
+
+@pytest.mark.usefixtures("clean_db", "clean_index")
+class TestOrgMetadataUpdate(object):
+
+    def test_package_count_is_updated(self):
+        org = factories.Organization()
+
+        result = helpers.call_action("organization_search", {}, q="*:*")
+        assert result["count"] == 1
+        assert result["results"][0]["package_count"] == 0
+
+        helpers.call_action(
+            "package_create",
+            {},
+            name="testing-package",
+            owner_org=org["id"]
+        )
+
+        result = helpers.call_action("organization_search", {}, q="*:*")
+        assert result["count"] == 1
+        assert result["results"][0]["package_count"] == 0
+
+        helpers.call_action("rebuild_organizations_index")
+
+        result = helpers.call_action("organization_search", {}, q="*:*")
+        assert result["count"] == 1
+        assert result["results"][0]["package_count"] == 1

--- a/ckanext/sitesearch/tests/test_rebuild.py
+++ b/ckanext/sitesearch/tests/test_rebuild.py
@@ -21,10 +21,13 @@ class TestRebuild:
         dataset = helpers.call_action(
             "package_create", {}, name="testing-package", owner_org=org["id"]
         )
+        helpers.call_action(
+            "package_create", {}, name="testing-package-2", owner_org=org["id"]
+        )
 
         result = helpers.call_action("organization_search", {}, q="*:*")
         assert result["count"] == 1
-        assert result["results"][0]["package_count"] == 1
+        assert result["results"][0]["package_count"] == 2
 
         helpers.call_action(
             "package_delete",
@@ -34,7 +37,7 @@ class TestRebuild:
 
         result = helpers.call_action("organization_search", {}, q="*:*")
         assert result["count"] == 1
-        assert result["results"][0]["package_count"] == 0
+        assert result["results"][0]["package_count"] == 1
 
     def test_group_package_count_is_updated(self):
         group = factories.Group()
@@ -45,6 +48,7 @@ class TestRebuild:
         assert result["results"][0]["package_count"] == 0
 
         dataset = factories.Dataset(owner_org=org["id"])
+        dataset2 = factories.Dataset(owner_org=org["id"])
 
         helpers.call_action(
             "member_create",
@@ -53,10 +57,17 @@ class TestRebuild:
             object_type="package",
             capacity="member",
         )
+        helpers.call_action(
+            "member_create",
+            object=dataset2["id"],
+            id=group["id"],
+            object_type="package",
+            capacity="member",
+        )
 
         result = helpers.call_action("group_search", {}, q="*:*")
         assert result["count"] == 1
-        assert result["results"][0]["package_count"] == 1
+        assert result["results"][0]["package_count"] == 2
 
         helpers.call_action(
             "package_delete",
@@ -66,4 +77,4 @@ class TestRebuild:
 
         result = helpers.call_action("group_search", {}, q="*:*")
         assert result["count"] == 1
-        assert result["results"][0]["package_count"] == 0
+        assert result["results"][0]["package_count"] == 1

--- a/ckanext/sitesearch/tests/test_rebuild.py
+++ b/ckanext/sitesearch/tests/test_rebuild.py
@@ -1,9 +1,17 @@
 import pytest
 
+from ckan.lib.search import clear_all
 from ckan.tests import factories, helpers
 
 
-@pytest.mark.usefixtures("clean_db", "clean_index")
+@pytest.fixture(scope="class")
+def reset():
+    yield
+    helpers.reset_db()
+    clear_all()
+
+
+@pytest.mark.usefixtures("reset")
 class TestOrgMetadataUpdate(object):
     def test_org_package_count_is_updated(self):
         org = factories.Organization()


### PR DESCRIPTION
### Issue

Currently when a package is created/deleted, the organization/group index is not refreshed. This means that any call to `organization_search`/`group_search` will not return an up-to-date `package_count` attribute.

### Solution

- Refactored all the rebuild logic used in the `cli` command into a new lib called `rebuild`
- Created `package_create` chained action that calls a rebuild on the organization if the new dataset actually belongs to an Organization.
- Created `package_delete` chained action that iterates though all the package's groups and rebuild it's index.
- Created `member_create` chained action to rebuild the groups index if the action if for actually adding a package to a group.

### Notes

I like the idea of a rebuild module since it isolates the responsibility to update the index to the own entity. Instead of calling an `organization_show` in the `package_create` we simply delegate to the organization itself the action of rebuilding it's own index.

### Testing Notes

CKAN's fixtures are designed for each test to ensure the database is cleaned **before** running (instead of the canonical way of cleaning the database after running). This makes that the current implementation of fixtures to fail when doing several test runs because `TestGroupOrOrgSearch` will still have leftovers of the last test in the previous run. (Adding a "clean_db" fixture clashes with "group_search_fixtures")

Also, CKAN's fixtures are not conistent in the way they add/remove tables to the database. This can cause `clean_db` to fail cleaning the `pages` tables since it is found in the model metadata but not in the database itself (or vice versa). This scenario can happen when tests are executed unitarily. To "fix" it, just execute the whole suite of tests. (`pytest ckanext/sitesearch`)

To fix this we force a `teardown_class` method cleaning the index and database.