### PR TITLE
Pages module is not loaded at import time using cli

### DIFF
--- a/ckanext/sitesearch/lib/rebuild.py
+++ b/ckanext/sitesearch/lib/rebuild.py
@@ -14,9 +14,6 @@ from ckanext.sitesearch.lib.index import (
 )
 from sqlalchemy.sql.expression import false, true
 
-if plugin_loaded("pages"):
-    from ckanext.pages.db import Page
-
 log = logging.getLogger(__name__)
 
 
@@ -79,7 +76,9 @@ def rebuild_users(defer_commit=False, force=False, quiet=True, entity_id=None):
 
 def rebuild_pages(defer_commit=False, force=False, quiet=True, entity_id=None):
 
-    if not plugin_loaded("pages"):
+    if plugin_loaded("pages"):
+        from ckanext.pages.db import Page
+    else:
         raise RuntimeError("The `pages` plugin needs to be enabled")
 
     if entity_id:

--- a/ckanext/sitesearch/tests/test_cli.py
+++ b/ckanext/sitesearch/tests/test_cli.py
@@ -98,3 +98,7 @@ class TestSiteSearchCLI:
         search_result = helpers.call_action("organization_search")
         assert search_result["count"] == 1
         assert search_result["results"][0]["id"] == org["id"]
+
+    def test_rebuild_pages_invoked_correctly(self, cli):
+        result = cli.invoke(ckan, ["sitesearch", "rebuild", "pages"])
+        assert not result.exit_code


### PR DESCRIPTION
When executing the command `ckan sitesearch rebuild pages` the current implementation throws a NameError:

```
Traceback (most recent call last):
  File "/usr/lib/ckan/venv/bin/ckan", line 8, in <module>
    sys.exit(ckan())
  File "/usr/lib/ckan/venv/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/ckan/venv/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/lib/ckan/venv/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/ckan/venv/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/ckan/venv/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/ckan/venv/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/ckan/venv/lib/python3.8/site-packages/ckanext/sitesearch/cli.py", line 56, in rebuild
    rebuild_pages(defer_commit, force, quiet, entity_id)
  File "/usr/lib/ckan/venv/lib/python3.8/site-packages/ckanext/sitesearch/lib/rebuild.py", line 91, in rebuild_pages
    pages = Page.pages()
NameError: name 'Page' is not defined
```

This is because this condition evaluate to false when loading the module:

```python
    if plugin_loaded("pages"):
        from ckanext.pages.db import Page
```

Moving this import inside the method works properly although I'm not sure why or how CKAN's cli manages imports and plugins load.

I cannot understand why this import worked when it was under the `cli.py` module, but not under `lib/rebuild.py`. 🤔 