### PR TITLE
Rebuild Organizations on package_update

### DIFF
--- a/ckanext/sitesearch/logic/chained_action.py
+++ b/ckanext/sitesearch/logic/chained_action.py
@@ -36,6 +36,26 @@ def package_delete(up_func, context, data_dict):
 
 
 @toolkit.chained_action
+def package_update(up_func, context, data_dict):
+    package_id = toolkit.get_or_bust(data_dict, "id")
+    pkg = model.Package.get(package_id)
+    if not pkg:
+        raise toolkit.ObjectNotFound
+    old_org = pkg.owner_org
+
+    data_dict = up_func(context, data_dict)
+    new_org = data_dict.get("owner_org", None)
+
+    if old_org != new_org:
+        if old_org:
+            rebuild.rebuild_orgs(entity_id=old_org)
+        if new_org:
+            rebuild.rebuild_orgs(entity_id=new_org)
+
+    return data_dict
+
+
+@toolkit.chained_action
 def organization_create(up_func, context, data_dict):
 
     data_dict = up_func(context, data_dict)

--- a/ckanext/sitesearch/plugin.py
+++ b/ckanext/sitesearch/plugin.py
@@ -41,6 +41,7 @@ class SitesearchPlugin(plugins.SingletonPlugin):
             "user_delete": chained_action.user_delete,
             "package_create": chained_action.package_create,
             "package_delete": chained_action.package_delete,
+            "package_update": chained_action.package_update,
             "member_create": chained_action.member_create,
         }
         if plugins.plugin_loaded("pages"):

--- a/ckanext/sitesearch/tests/test_rebuild.py
+++ b/ckanext/sitesearch/tests/test_rebuild.py
@@ -78,3 +78,27 @@ class TestRebuild:
         result = helpers.call_action("group_search", {}, q="*:*")
         assert result["count"] == 1
         assert result["results"][0]["package_count"] == 1
+
+    def test_orgs_are_rebuild_when_updating_package_owner_org(self):
+        org = factories.Organization()
+        dataset = factories.Dataset(owner_org=org["id"])
+
+        result = helpers.call_action("organization_search", {}, q="*:*")
+        assert result["count"] == 1
+        assert result["results"][0]["package_count"] == 1
+
+        new_org = factories.Organization()
+
+        helpers.call_action(
+            "package_update", {}, id=dataset["id"], owner_org=new_org["id"]
+        )
+
+        result = helpers.call_action("organization_search", {}, q=f'name:{org["name"]}')
+        assert result["count"] == 1
+        assert result["results"][0]["package_count"] == 0
+
+        result = helpers.call_action(
+            "organization_search", {}, q=f'name:{new_org["name"]}'
+        )
+        assert result["count"] == 1
+        assert result["results"][0]["package_count"] == 1


### PR DESCRIPTION
Following #3 this PR covers the case when the Package's organization is updated.

We should trigger a rebuild both in the new org and the old org to properly reflect the `package_count` in the index.