### PR TITLE
Fix tests for 2.10

### DIFF
--- a/ckanext/sitesearch/tests/test_blueprints.py
+++ b/ckanext/sitesearch/tests/test_blueprints.py
@@ -45,11 +45,11 @@ class TestDatasetCreationWorkflow:
     @pytest.mark.ckan_config("ckan.auth.create_unowned_dataset", True)
     def test_dataset_creation_workflow_index_properly(self, app):
 
-        sysadmin = factories.Sysadmin()
+        sysadmin = factories.SysadminWithToken()
         organization = factories.Organization()
 
         url = tk.url_for("dataset.new")
-        extra_environ = {"REMOTE_USER": sysadmin["name"]}
+        extra_environ = {"Authorization": sysadmin["token"]}
         app.post(
             url,
             extra_environ=extra_environ,


### PR DESCRIPTION
While working against `master` this Blueprint test fails with a CSRF error.

I think it is related to changes made in https://github.com/ckan/ckan/pull/7096/files so I have updated the test to use `Authorization` instead of `REMOTE_USER`.