### PR TITLE
Don't install ckanext-pages in dev-requirements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,8 @@ jobs:
       run: |
         pip install -r dev-requirements.txt
         pip install -e .
+        
+        pip install -e git+https://github.com/ckan/ckanext-pages.git#egg=ckanext-pages
     - name: Setup extension
       # Extra initialization steps
       run: |

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,1 @@
--e git+https://github.com/ckan/ckanext-pages.git#egg=ckanext-pages
 pytest-ckan


### PR DESCRIPTION
Installing latest ckanext-pages from dev-requirements broke our local environments as we don't yet use latest pages.

Ckanext-pages should be installed when needed, not by default.